### PR TITLE
Prevent stack overflow when missing href

### DIFF
--- a/lib/arbor/model/abstract.rb
+++ b/lib/arbor/model/abstract.rb
@@ -3,7 +3,7 @@ require 'arbor/model/serialiser'
 module Arbor
   module Model
     class Abstract
-      attr_accessor :api_client, :entity_type, :attribute_names, :attribute_lock
+      attr_accessor :api_client, :entity_type, :attribute_names, :attribute_lock, :href
 
       def initialize(attributes)
         @attribute_names = []


### PR DESCRIPTION
When a resource doesn't have a `href` attribute, it hits method_missing,
which tries to load the full resource, which subsequently calls href,
and then we enter a loop and ultimately the stack overflows.

The solution is to add href to attr_accessor so that calls to href never
hit method_missing.

Closes #13 