### PR TITLE
Update deprecated BigDecimal constructor

### DIFF
--- a/lib/arbor/api.rb
+++ b/lib/arbor/api.rb
@@ -25,7 +25,7 @@ module Arbor
 
       data['changes'].each do |c|
         c['entityType'] = "change"
-        @highest_revision = [highest_revision, BigDecimal.new(c['toRevision'])].max
+        @highest_revision = [highest_revision, BigDecimal(c['toRevision'])].max
       end
 
       unmarshall_data(data, 'changes')


### PR DESCRIPTION
"BigDecimal.new is deprecated. Prefer BigDecimal() instead